### PR TITLE
Take MembershipUser.IsApproved into account in various cases

### DIFF
--- a/src/IdentityServer4.Contrib.Membership/MembershipProfileService.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipProfileService.cs
@@ -84,7 +84,7 @@ namespace IdentityServer4.Contrib.Membership
                 return;
             }
 
-            context.IsActive = !user.IsLockedOut;
+            context.IsActive = !user.IsLockedOut && user.IsApproved;
         }
 
         private static Guid ParseGuid(string sub)

--- a/src/IdentityServer4.Contrib.Membership/MembershipService.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipService.cs
@@ -98,7 +98,7 @@ namespace IdentityServer4.Contrib.Membership
 
             var user = await membershipRepository.FindUserByUsername(username).ConfigureAwait(false);
 
-            return isPasswordCorrect && user.IsApproved;
+            return isPasswordCorrect && user?.IsApproved == true;
         }
 
         /// <summary>Updates the password for the given username</summary>

--- a/src/IdentityServer4.Contrib.Membership/MembershipService.cs
+++ b/src/IdentityServer4.Contrib.Membership/MembershipService.cs
@@ -96,7 +96,9 @@ namespace IdentityServer4.Contrib.Membership
                                           .ConfigureAwait(false);
             }
 
-            return isPasswordCorrect;
+            var user = await membershipRepository.FindUserByUsername(username).ConfigureAwait(false);
+
+            return isPasswordCorrect && user.IsApproved;
         }
 
         /// <summary>Updates the password for the given username</summary>


### PR DESCRIPTION
According to the documentation of the [MembershipUser.IsApproved](https://msdn.microsoft.com/en-us/library/system.web.security.membershipuser.isapproved(v=vs.110).aspx), `ValidateUser` must return `false` if `MembershipUser.IsApproved` is `false`
The same applies to the ability to sign in.

// Thanks for this project 👍 