### PR TITLE
Upgrade to the latest IdentityServer4 version (2.3.2)

### DIFF
--- a/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
+++ b/src/IdentityServer4.Contrib.Membership/IdentityServer4.Contrib.Membership.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitLink" Version="3.1.0" PrivateAssets="All" />
-    <PackageReference Include="IdentityServer4" Version="2.2.0" />
+    <PackageReference Include="IdentityServer4" Version="2.3.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The solution needs to be recompiled against the new IdentityServer4 version, because some of models were moved to the `IdentityServer4.Storage` assembly.